### PR TITLE
Fix bug with paths containing subdirectories

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -71,7 +71,7 @@ function get_icon_sage_path($icon)
 	$icon_path_rel = RelPath::getRelativePath($icon_path_abs, get_svg_path());
 
 	// 6. Final icon path without extension expected
-	$icon_imgpath_noext = pathinfo($icon_path_rel, PATHINFO_FILENAME);
+	$icon_imgpath_noext = substr($icon_path_rel, 0, strrpos($icon_path_rel, '.'));
 
 	return $icon_imgpath_noext;
 }


### PR DESCRIPTION
Previously, if an icon path containing a subdirectory (eg. 'icons/myicon') was passed to `get_icon_sage_path($icon)`, the subdirectory would be stripped from the final hashed path, resulting in an exception due to the file not being found.

More details: https://github.com/Log1x/blade-svg-sage/issues/11