### PR TITLE
add fallback icon if icon not found in folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ add_filter('bladesvg', function () {
         'spritesheet_url' => '',
         'sprite_prefix' => '',
         'inline' => true,
-        'class' => ''
+        'class' => '',
+        'fallback_name' => 'fallback'
     ];
 });
 ```


### PR DESCRIPTION
This code adds the option to set an fallback svg. So if the blade directive is used dynamically and an icon is deleted, the page doesn't throw a 500 error. Instead it displays the fallback svg.

If the fallback isn't set, the 500 error will be there as before